### PR TITLE
ref: NewVRRPmulticastPacket()

### DIFF
--- a/encapsulation_test.go
+++ b/encapsulation_test.go
@@ -1,0 +1,37 @@
+package govrrp
+
+import (
+	"net"
+	"testing"
+)
+
+func TestNewVRRPmulticastPacket(t *testing.T) {
+	type mcastPacket struct {
+		iface           *net.Interface
+		advertAddresses []net.IP
+		result          bool
+	}
+
+	iface, err := GetInterface()
+	if err != nil {
+		t.Fatalf("FAILED: %v\n", err)
+	}
+
+	pcktTable := []mcastPacket{
+		{iface, []net.IP{net.IPv4(192, 168, 8, 99), net.IPv4(172, 23, 44, 6)}, true},
+		{iface, []net.IP{net.ParseIP("ff02::114")}, false},
+	}
+
+	for _, tcase := range pcktTable {
+		_, err := NewVRRPmulticastPacket(tcase.iface, 2, tcase.advertAddresses)
+
+		// TODO ...
+		// just a placeholder for now
+		if (err != nil) || (err == nil && tcase.result) || (err == nil && !tcase.result) {
+			t.Logf("PASSED %v\n", tcase)
+		} else {
+			t.Errorf("FAILED Got: %v Expected %v; Error: %v\n", !tcase.result, tcase.result, err)
+		}
+	}
+
+}

--- a/vrrp.go
+++ b/vrrp.go
@@ -25,7 +25,7 @@ const (
 	vrrpHdrSize           = 8            // Lenght of VRRP header, bytes
 	PseudoHeaderSize      = 12           // Size of pseudo-header, bytes
 	VRRPprotoNumber       = 112          // The IP protocol number assigned by the IANA
-	VRRPipv4MulticastAddr = "224.0.0.18" //The IP multicast address as assigned by the IANA
+	VRRPipv4MulticastAddr = "224.0.0.18" // The IP multicast address as assigned by the IANA
 )
 
 var (
@@ -35,12 +35,6 @@ var (
 type Marshaler interface {
 	Marshal() ([]byte, error)
 	Unmarshal([]byte) error
-}
-
-// VRRPpacket is a binary representation of VRRP packet
-type VRRPpacket struct {
-	PseudoHeader []byte
-	Header       []byte
 }
 
 // VRRPmessage represents a VRRP message.

--- a/vrrp_test.go
+++ b/vrrp_test.go
@@ -64,37 +64,6 @@ func TestMarshal(t *testing.T) {
 	}
 }
 
-func TestNewVRRPmulticastPacket(t *testing.T) {
-	type mcastPacket struct {
-		iface           *net.Interface
-		advertAddresses []net.IP
-		result          bool
-	}
-
-	iface, err := GetInterface()
-	if err != nil {
-		t.Fatalf("FAILED: %v\n", err)
-	}
-
-	pcktTable := []mcastPacket{
-		{iface, []net.IP{net.IPv4(192, 168, 8, 99), net.IPv4(172, 23, 44, 6)}, true},
-		{iface, []net.IP{net.ParseIP("ff02::114")}, false},
-	}
-
-	for _, tcase := range pcktTable {
-		_, err := NewVRRPmulticastPacket(tcase.iface, 2, tcase.advertAddresses)
-
-		// TODO ...
-		// just a placeholder for now
-		if (err != nil) || (err == nil && tcase.result) || (err == nil && !tcase.result) {
-			t.Logf("PASSED %v\n", tcase)
-		} else {
-			t.Errorf("FAILED Got: %v Expected %v; Error: %v\n", !tcase.result, tcase.result, err)
-		}
-	}
-
-}
-
 func TestChecksum(t *testing.T) {
 	type mcastPacket struct {
 		iface           *net.Interface
@@ -128,13 +97,6 @@ func TestChecksum(t *testing.T) {
 				t.Fatalf("FAILED %v\n", err)
 			}
 		}
-		vrrp, err := packet.VRRPpacket.Marshal()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		csum := Checksum(vrrp)
-		packet.VRRPpacket.SetChecksum(csum)
 
 		pass, err := VerifyChecksum(srcAddr, net.ParseIP(VRRPipv4MulticastAddr).To4(), packet.VRRPpacket.Header)
 		if err != nil {


### PR DESCRIPTION
 - VRRP checksum is being set in NewVRRPmulticastPacket(), no need to call the methods from the outside
 - (p *VRRPpacket) Marshal() was renamed to (p *VRRPpacket) GetVRRPpacket()
